### PR TITLE
Add Portworx manifests for operator and storage cluster

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -1,0 +1,19 @@
+# Portworx Manifests
+
+This repository contains Kubernetes (K8s) manifests needed for deploying the Portworx Operator and the Portworx StorageCluster Custom Resource Definition (CRD). These manifests are stored in the `storage` folder.
+
+## Purpose
+
+The `storage` folder serves as a collection of YAML files, or 'manifests', which are used to create, configure and manage Kubernetes resources for deploying the Portworx Operator and the StorageCluster CRD. 
+
+Portworx is a cloud-native storage platform that provides high availability, data protection, data security, and data mobility. The Portworx Operator manages the lifecycle of Portworx, and the StorageCluster CRD represents a Portworx Cluster.
+
+The manifests are named in the numerical order they need to be deployed. This order is important and should be followed to ensure a correct setup.
+
+## Future Work
+
+This is an initial setup for the Portworx deployment. As the project progresses, these manifests will be refined, tested, and tweaked to implement best security practices. 
+
+At the moment, we are using a basic configuration to establish a baseline functionality and ensure everything is working as expected within zarf
+
+Please follow this repository to keep up with the changes and improvements over time.

--- a/storage/manifests/01-px-operator.yaml
+++ b/storage/manifests/01-px-operator.yaml
@@ -1,0 +1,77 @@
+# SOURCE: https://install.portworx.com/?comp=pxoperator&kbver=1.26.3
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portworx-operator
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: portworx-operator
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: portworx-operator
+subjects:
+- kind: ServiceAccount
+  name: portworx-operator
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: portworx-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portworx-operator
+  namespace: kube-system
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      name: portworx-operator
+  template:
+    metadata:
+      labels:
+        name: portworx-operator
+    spec:
+      containers:
+      - name: portworx-operator
+        imagePullPolicy: Always
+        image: portworx/px-operator:23.5.0
+        command:
+        - /operator
+        - --verbose
+        - --driver=portworx
+        - --leader-elect=true
+        env:
+        - name: OPERATOR_NAME
+          value: portworx-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                    - portworx-operator
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: portworx-operator

--- a/storage/manifests/02-px-stc.yaml
+++ b/storage/manifests/02-px-stc.yaml
@@ -1,0 +1,33 @@
+# SOURCE: https://install.portworx.com/?operator=true&mc=false&kbver=1.26.3&b=true&j=auto&c=px-cluster-0766119b-0327-466f-97db-e74fd3ce231d&stork=true&csi=true&mon=true&tel=false&st=k8s&promop=true
+kind: StorageCluster
+apiVersion: core.libopenstorage.org/v1
+metadata:
+  name: px-cluster-0766119b-0327-466f-97db-e74fd3ce231d
+  namespace: kube-system
+  annotations:
+    portworx.io/install-source: "https://install.portworx.com/?operator=true&mc=false&kbver=1.26.3&b=true&j=auto&c=px-cluster-0766119b-0327-466f-97db-e74fd3ce231d&stork=true&csi=true&mon=true&tel=false&st=k8s&promop=true"
+spec:
+  image: portworx/oci-monitor:2.13.6
+  imagePullPolicy: Always
+  kvdb:
+    internal: true
+  storage:
+    useAll: true
+    journalDevice: auto
+  secretsProvider: k8s
+  stork:
+    enabled: true
+    args:
+      webhook-controller: "true"
+  autopilot:
+    enabled: true
+  csi:
+    enabled: true
+  monitoring:
+    telemetry:
+      enabled: false
+    prometheus:
+      enabled: true
+      exportMetrics: true
+  tolerations:
+  - operator: "Exists"


### PR DESCRIPTION
This pull request introduces a new folder in the repository called storage. This folder contains K8s manifests needed for deploying the Portworx Operator and the Portworx StorageCluster Custom Resource Definition.

The manifests are named in the numerical order they need to be deployed. This order is important and should be followed to ensure a correct setup.