### PR TITLE
51 clustername sanitization leaves trailing slash which makes it an invalid hostname

### DIFF
--- a/.github/workflows/arkime.yaml
+++ b/.github/workflows/arkime.yaml
@@ -18,8 +18,8 @@ jobs:
     uses: ./.github/workflows/package.yaml
     secrets: inherit
     with:
-    # The REF_NAME is referencing the tag or branch name in the arkime repo (not the dco-core repo)
-    # if you're making a change to the capability chart change the REF_NAME to the tag or branch name in the capability repo
+      # The REF_NAME is referencing the tag or branch name in the arkime repo (not the dco-core repo)
+      # if you're making a change to the capability chart change the REF_NAME to the tag or branch name in the capability repo
       REF_NAME: "30-update-to-latest-arkime-version"
       REF_TYPE: "branch"
       ZARF_PACKAGE_NAME: zarf-package-arkime-amd64.tar.zst

--- a/.github/workflows/arkime.yaml
+++ b/.github/workflows/arkime.yaml
@@ -20,8 +20,8 @@ jobs:
     with:
     # The REF_NAME is referencing the tag or branch name in the arkime repo (not the dco-core repo)
     # if you're making a change to the capability chart change the REF_NAME to the tag or branch name in the capability repo
-      REF_NAME: "v4.2.0-2"
-      REF_TYPE: "tag"
+      REF_NAME: "30-update-to-latest-arkime-version"
+      REF_TYPE: "branch"
       ZARF_PACKAGE_NAME: zarf-package-arkime-amd64.tar.zst
-      IMAGE_TAG: "v4.2.0-2"
+      IMAGE_TAG: "30-update-to-latest-arkime-version"
       COMPONENT: "arkime"


### PR DESCRIPTION
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Description

Fixes #51 
Closes #51 

# How Has This Been Tested?

TLDR; This has been tested via the standard PR workflow on the source branch.

Originally, this was tested over in naps-dev/arkime#31 in order to unblock the validation of naps-dev/arkime#30. 

Since the fixes were actually in dco-core, I created this issue and corresponding branch and PR. The branch was taken from the same dco-core branch used in naps-dev/arkime#31, i.e. 30-update-to-latest-arkime-version, after updating it to main. 
