### PR TITLE
Update storage cluster manifest:

### DIFF
--- a/storage/manifests/02-px-stc.yaml
+++ b/storage/manifests/02-px-stc.yaml
@@ -1,11 +1,10 @@
-# SOURCE: https://install.portworx.com/?operator=true&mc=false&kbver=1.26.3&b=true&j=auto&c=px-cluster-0766119b-0327-466f-97db-e74fd3ce231d&stork=true&csi=true&mon=true&tel=false&st=k8s&promop=true
-kind: StorageCluster
 apiVersion: core.libopenstorage.org/v1
+kind: StorageCluster
 metadata:
-  name: px-cluster-0766119b-0327-466f-97db-e74fd3ce231d
-  namespace: kube-system
   annotations:
-    portworx.io/install-source: "https://install.portworx.com/?operator=true&mc=false&kbver=1.26.3&b=true&j=auto&c=px-cluster-0766119b-0327-466f-97db-e74fd3ce231d&stork=true&csi=true&mon=true&tel=false&st=k8s&promop=true"
+    portworx.io/disable-storage-class: "true"
+  name: portworx
+  namespace: kube-system
 spec:
   image: portworx/oci-monitor:2.13.6
   imagePullPolicy: Always
@@ -29,5 +28,14 @@ spec:
     prometheus:
       enabled: true
       exportMetrics: true
-  tolerations:
-  - operator: "Exists"
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+  deleteStrategy:
+    type: UninstallAndWipe
+  placement:
+    tolerations:
+    - operator: "Exists"
+
+

--- a/storage/manifests/03-px-sc.yaml
+++ b/storage/manifests/03-px-sc.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: px
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/portworx-volume
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  repl: "1"
+  priority_io: high
+  io_profile: auto
+  stork-volume-provisioner.alpha.kubernetes.io/storage-pool: "1"
+allowVolumeExpansion: true


### PR DESCRIPTION
- Modify the manifest to ensure all components run on every node, regardless of taints and master nodes.
- Conduct thorough testing to confirm successful execution of a storage cluster on a single master node.

Adjust default PX storage classes for the storage cluster:

- Disable PX storage classes that are not valid by default.

Add a custom storage class:

- Create a new storage class named 'px' with specific configurations.
- Configure the 'px' storage class to allocate a single Kubernetes PV on a single node.
- Set the 'px' storage class as the default storage class for the cluster.
- Configure the 'px' storage class to automatically utilize storage pool 1 by default, which is the primary RAID 0 performance pool with 70TB of usable space.



